### PR TITLE
add note on unraid

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ This container uses [Docker in Docker](https://www.docker.com/blog/docker-can-no
 
 **Unlike other containers the web interface port (default 443) needs to be set for the env variable `KASM_PORT` and both the inside and outside port IE for 4443 `KASM_PORT=4443` `-p 4443:4443`**
 
+**Unraid users due to the DinD storage layer `/opt/` should be mounted directly to a disk IE `/mnt/disk1/appdata/path` or optimally with a cache disk at `/mnt/cache/appdata/path`**
+
 Access the installation wizard at https://`your ip`:3000 and follow the instructions there. Once setup is complete access https://`your ip`:443 and login with the credentials you entered during setup. The default users are:
 
 * admin@kasm.local

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -80,6 +80,8 @@ app_setup_block: |
 
   **Unlike other containers the web interface port (default 443) needs to be set for the env variable `KASM_PORT` and both the inside and outside port IE for 4443 `KASM_PORT=4443` `-p 4443:4443`**
 
+  **Unraid users due to the DinD storage layer `/opt/` should be mounted directly to a disk IE `/mnt/disk1/appdata/path` or optimally with a cache disk at `/mnt/cache/appdata/path`**
+
   Access the installation wizard at https://`your ip`:3000 and follow the instructions there. Once setup is complete access https://`your ip`:443 and login with the credentials you entered during setup. The default users are:
 
   * admin@kasm.local


### PR DESCRIPTION
With multiple support requests adding a note on storage config for /opt.

The fuse FS does not work with DinD storage properly. 