### PR TITLE
pin docker compose to upstream recommended version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,6 @@ RUN \
     containerd.io \
     docker-ce \
     docker-ce-cli \
-    docker-compose-plugin \
     drm-info \
     e2fsprogs \
     fuse-overlayfs \
@@ -51,6 +50,12 @@ RUN \
     sudo \
     uidmap \
     xfsprogs && \
+  echo "**** compose install ****" && \
+  mkdir -p /usr/local/lib/docker/cli-plugins && \
+  curl -L \
+    https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-$(uname -s)-$(uname -m) -o \
+    /usr/local/lib/docker/cli-plugins/docker-compose && \
+  chmod +x /usr/local/lib/docker/cli-plugins/docker-compose && \
   echo "**** dind setup ****" && \
   useradd -U dockremap && \
   usermod -G dockremap dockremap && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -34,7 +34,6 @@ RUN \
     containerd.io \
     docker-ce \
     docker-ce-cli \
-    docker-compose-plugin \
     drm-info \
     e2fsprogs \
     fuse-overlayfs \
@@ -51,6 +50,12 @@ RUN \
     sudo \
     uidmap \
     xfsprogs && \
+  echo "**** compose install ****" && \
+  mkdir -p /usr/local/lib/docker/cli-plugins && \
+  curl -L \
+    https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-$(uname -s)-$(uname -m) -o \
+    /usr/local/lib/docker/cli-plugins/docker-compose && \
+  chmod +x /usr/local/lib/docker/cli-plugins/docker-compose && \
   echo "**** dind setup ****" && \
   useradd -U dockremap && \
   usermod -G dockremap dockremap && \

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **28.03.23:** - Pin compose to 2.5.0 to be in sync with upstream requirements.
 * **05.11.22:** - Rebase to Jammy, add support for GPUs, add support for Gamepads.
 * **23.09.22:** - Migrate to s6v3.
 * **02.07.22:** - Initial Release.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -105,6 +105,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "28.03.23:", desc: "Pin compose to 2.5.0 to be in sync with upstream requirements." }
   - { date: "05.11.22:", desc: "Rebase to Jammy, add support for GPUs, add support for Gamepads." }
   - { date: "23.09.22:", desc: "Migrate to s6v3." }
   - { date: "02.07.22:", desc: "Initial Release." }


### PR DESCRIPTION
There are some syntax errors the new version of Compose picks up during installation in the DinD layer. Need to pin to 2.5.0 for the stable branch only. The develop builds can continue to use the latest compose plugin from their repos. 