### PR TITLE
support mtu change

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ services:
       - KASM_PORT=443
       - DOCKER_HUB_USERNAME=USER #optional
       - DOCKER_HUB_PASSWORD=PASS #optional
+      - DOCKER_MTU=1500 #optional
     volumes:
       - /path/to/data:/opt
       - /path/to/profiles:/profiles #optional
@@ -142,6 +143,7 @@ docker run -d \
   -e KASM_PORT=443 \
   -e DOCKER_HUB_USERNAME=USER `#optional` \
   -e DOCKER_HUB_PASSWORD=PASS `#optional` \
+  -e DOCKER_MTU=1500 `#optional` \
   -p 3000:3000 \
   -p 443:443 \
   -v /path/to/data:/opt \

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e KASM_PORT=443` | Specify the port you bind to the outside for Kasm Workspaces. |
 | `-e DOCKER_HUB_USERNAME=USER` | Optionally specify a DockerHub Username to pull private images. |
 | `-e DOCKER_HUB_PASSWORD=PASS` | Optionally specify a DockerHub password to pull private images. |
+| `-e DOCKER_MTU=1500` | Optionally specify the mtu options passed to dockerd. |
 | `-v /opt` | Docker and installation storage. |
 | `-v /profiles` | Optionally specify a path for persistent profile storage. |
 | `-v /dev/input` | Optional for gamepad support. |

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -52,6 +52,7 @@ opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "DOCKER_HUB_USERNAME", env_value: "USER", desc: "Optionally specify a DockerHub Username to pull private images." }
   - { env_var: "DOCKER_HUB_PASSWORD", env_value: "PASS", desc: "Optionally specify a DockerHub password to pull private images." }
+  - { env_var: "DOCKER_MTU", env_value: "1500", desc: "Optionally specify the mtu options passed to dockerd" }
 
 opt_param_usage_include_vols: true
 opt_param_volumes:

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -52,7 +52,7 @@ opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "DOCKER_HUB_USERNAME", env_value: "USER", desc: "Optionally specify a DockerHub Username to pull private images." }
   - { env_var: "DOCKER_HUB_PASSWORD", env_value: "PASS", desc: "Optionally specify a DockerHub password to pull private images." }
-  - { env_var: "DOCKER_MTU", env_value: "1500", desc: "Optionally specify the mtu options passed to dockerd" }
+  - { env_var: "DOCKER_MTU", env_value: "1500", desc: "Optionally specify the mtu options passed to dockerd." }
 
 opt_param_usage_include_vols: true
 opt_param_volumes:

--- a/root/usr/local/bin/dockerd-entrypoint.sh
+++ b/root/usr/local/bin/dockerd-entrypoint.sh
@@ -116,6 +116,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	; then
 		# generate certs and use TLS if requested/possible (default in 19.03+)
 		set -- dockerd \
+            --mtu="${dockermtu:-1500}" \
 			--host="$dockerSocket" \
 			--host=tcp://0.0.0.0:2376 \
 			--tlsverify \
@@ -127,6 +128,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	else
 		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
 		set -- dockerd \
+            --mtu="${dockermtu:-1500}" \
 			--host="$dockerSocket" \
 			"$@"
 		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"

--- a/root/usr/local/bin/dockerd-entrypoint.sh
+++ b/root/usr/local/bin/dockerd-entrypoint.sh
@@ -116,7 +116,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	; then
 		# generate certs and use TLS if requested/possible (default in 19.03+)
 		set -- dockerd \
-            --mtu="${dockermtu:-1500}" \
+            --mtu="${DOCKER_MTU:-1500}" \
 			--host="$dockerSocket" \
 			--host=tcp://0.0.0.0:2376 \
 			--tlsverify \
@@ -128,7 +128,7 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	else
 		# TLS disabled (-e DOCKER_TLS_CERTDIR='') or missing certs
 		set -- dockerd \
-            --mtu="${dockermtu:-1500}" \
+            --mtu="${DOCKER_MTU:-1500}" \
 			--host="$dockerSocket" \
 			"$@"
 		DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS="${DOCKERD_ROOTLESS_ROOTLESSKIT_FLAGS:-} -p 0.0.0.0:2375:2375/tcp"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-kasm/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
This PR supports Kasm deployed into Kubernetes and other virtualized networking that requires a mtu change from the dockerd default of 1500
## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
When Kasm deploys "workspaces" dind is used. Downloads hang and timeout and its because of the "overlayed" mtu set in the primary networking interface. eth0 (1500) -> cni0 (eg. 1450) -> docker0(1500)
## How Has This Been Tested?
Used images built in CI and verified options are passed and configured correctly. `docker inspect network bridge[hash]` and `docker exec "dev container hash" ps aux `
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://blog.zespre.com/dind-mtu-size-matters.html
https://bascht.com/tech/2021/04/08/kubernetes-docker-dind-mtu-issues-on-hetzner-cloud/
