### PR TITLE
add the default kasm users in the docker logic to allow container upgrades without wizard upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,8 @@ RUN \
   cp \
     /kasm_release/conf/database/seed_data/default_images_a* \
     /wizard/ && \
+  useradd -u 70 kasm_db && \
+  useradd kasm && \
   echo "**** cleanup ****" && \
   apt-get remove -y g++ gcc make && \
   apt-get -y autoremove && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -112,6 +112,8 @@ RUN \
   cp \
     /kasm_release/conf/database/seed_data/default_images_a* \
     /wizard/ && \
+  useradd -u 70 kasm_db && \
+  useradd kasm && \
   echo "**** cleanup ****" && \
   apt-get remove -y g++ gcc make && \
   apt-get -y autoremove && \

--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **24.09.24:** - Add base users in docker build logic to survive container upgrades.
 * **17.09.24:** - Update base image for 1.16.0 release and fix Nvidia support.
 * **16.02.24:** - Update base image for 1.15.0 release.
 * **22.08.23:** - Update base image for 1.14.0 release.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -116,6 +116,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "24.09.24:", desc: "Add base users in docker build logic to survive container upgrades." }
   - { date: "17.09.24:", desc: "Update base image for 1.16.0 release and fix Nvidia support." }
   - { date: "16.02.24:", desc: "Update base image for 1.15.0 release." }
   - { date: "22.08.23:", desc: "Update base image for 1.14.0 release." }


### PR DESCRIPTION
This adds the default Kasm users that are normally added in the installation or upgrade procedure. The install/upgrade logic skips the creation if they allready exists. 

Ref issues: 
https://github.com/linuxserver/docker-kasm/issues/59
https://github.com/linuxserver/docker-kasm/issues/52