### PR TITLE
Fix NVIDIA passthrough into Workspace containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ Following the upgrade, you will need to update any workspace image tags to match
 
 ### GPU Support
 
-During installation an option will be presented to force all Workspace containers to mount in and use a specific GPU. If using an NVIDIA GPU you will need to pass `-e NVIDIA_VISIBLE_DEVICES=all` or `--gpus all` and have the [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-container-toolkit) installed on the host. Also if using NVIDIA, Kasm Workspaces has [native NVIDIA support](https://docs.kasm.com/docs/latest/how-to/gpu/index.html) so you can optionally opt to simply use that instead of he manual override during installation.
+During installation an option will be presented to force all Workspace containers to mount in and use a specific GPU. If using an NVIDIA GPU you will need to pass `-e NVIDIA_VISIBLE_DEVICES=all` or `--gpus all` and have the [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-container-toolkit) installed on the host. Also if using NVIDIA, Kasm Workspaces has [native NVIDIA support](https://docs.kasm.com/docs/latest/how-to/gpu/index.html) so you can optionally opt to simply use that instead of the manual override during installation.
+
+When NVIDIA devices are passed to this container, a [CDI](https://github.com/cncf-tags/container-device-interface) specification describing them is generated inside the DinD layer on startup and the NVIDIA runtime is made the default one there. This is what allows the driver, and with it Vulkan and OpenGL, to reach the Workspace containers.
 
 ### Gamepad support
 
@@ -317,6 +319,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **07.08.26:** - Fix NVIDIA passthrough to Workspace containers by generating a CDI specification inside the DinD layer.
 * **04.08.26:** - Give kasm_manager a healthcheck start period so a cold start does not leave kasm_proxy created but never started.
 * **16.04.26:** - Update for 1.18.1 release. Use rolling service images. Bump docker to v29.
 * **13.11.25:** - Pin docker to v28 to avoid API deprecation issues.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -70,7 +70,9 @@ app_setup_block: |
 
   ### GPU Support
 
-  During installation an option will be presented to force all Workspace containers to mount in and use a specific GPU. If using an NVIDIA GPU you will need to pass `-e NVIDIA_VISIBLE_DEVICES=all` or `--gpus all` and have the [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-container-toolkit) installed on the host. Also if using NVIDIA, Kasm Workspaces has [native NVIDIA support](https://docs.kasm.com/docs/latest/how-to/gpu/index.html) so you can optionally opt to simply use that instead of he manual override during installation.
+  During installation an option will be presented to force all Workspace containers to mount in and use a specific GPU. If using an NVIDIA GPU you will need to pass `-e NVIDIA_VISIBLE_DEVICES=all` or `--gpus all` and have the [NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-container-toolkit) installed on the host. Also if using NVIDIA, Kasm Workspaces has [native NVIDIA support](https://docs.kasm.com/docs/latest/how-to/gpu/index.html) so you can optionally opt to simply use that instead of the manual override during installation.
+
+  When NVIDIA devices are passed to this container, a [CDI](https://github.com/cncf-tags/container-device-interface) specification describing them is generated inside the DinD layer on startup and the NVIDIA runtime is made the default one there. This is what allows the driver, and with it Vulkan and OpenGL, to reach the Workspace containers.
 
   ### Gamepad support
 
@@ -130,6 +132,7 @@ init_diagram: |
   "kasm:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "07.08.26:", desc: "Fix NVIDIA passthrough to Workspace containers by generating a CDI specification inside the DinD layer."}
   - {date: "04.08.26:", desc: "Give kasm_manager a healthcheck start period so a cold start does not leave kasm_proxy created but never started."}
   - {date: "16.04.26:", desc: "Update for 1.18.1 release. Use rolling service images. Bump docker to v29."}
   - {date: "13.11.25:", desc: "Pin docker to v28 to avoid API deprecation issues."}

--- a/root/etc/s6-overlay/s6-rc.d/init-config-kasm/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-config-kasm/run
@@ -13,6 +13,22 @@ if [[ -S /var/run/docker.sock ]]; then
   rm -f /var/run/docker.sock
 fi
 
+# The NVIDIA container toolkit on the host injects the driver into this container,
+# but nothing carries it over to the Workspace containers started inside the DinD
+# layer. Describe the devices and driver we were handed in a CDI specification, so
+# that dockerd here is able to inject them in turn, and make the NVIDIA runtime the
+# default one so Workspace containers pick it up without any per Workspace override.
+rm -f /etc/cdi/nvidia.yaml
+if [[ -e "/dev/nvidiactl" ]]; then
+    mkdir -p /etc/cdi
+    if nvidia-ctk cdi generate --output="/etc/cdi/nvidia.yaml"; then
+        nvidia-ctk config --in-place --set nvidia-container-runtime.mode="cdi"
+        nvidia-ctk runtime configure --runtime=docker --set-as-default
+    else
+        echo "**** NVIDIA devices were passed to this container but no CDI specification could be generated for them, Workspaces will not be GPU accelerated ****"
+    fi
+fi
+
 # Login to Dockerhub
 if [[ -n "${DOCKER_HUB_USERNAME}" ]]; then
     docker login --username "${DOCKER_HUB_USERNAME}" --password "${DOCKER_HUB_PASSWORD}"


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-kasm/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

The host's NVIDIA container toolkit injects the driver into this container, so the DinD layer itself has a working GPU — which is exactly what the issue reports: `nvidia-smi` and `vulkaninfo` behave there. Nothing carries that injection any further, though:

* `root/etc/docker/daemon.json` registers an `nvidia` runtime for the DinD daemon but never makes it the default,
* and no CDI specification describes the devices we were handed.

So the Workspace containers Kasm creates inside the DinD layer come up as plain `runc` containers, with no driver libraries and no Vulkan ICD.

This adds a GPU step to `init-config-kasm`, which is a oneshot that completes before `svc-docker` starts `dockerd`. It only fires when NVIDIA devices are actually present in the container (`/dev/nvidiactl`), and then:

1. `nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml` — describes the device nodes, driver libraries, binaries and Vulkan/EGL/GLX loader configuration that were injected into this container;
2. `nvidia-ctk config --in-place --set nvidia-container-runtime.mode=cdi` — points the NVIDIA runtime at that specification instead of re-discovering the driver at container creation time;
3. `nvidia-ctk runtime configure --runtime=docker --set-as-default` — makes the NVIDIA runtime the default one for the DinD daemon.

The specification is removed and regenerated on every start, so a host driver upgrade is picked up rather than cached. Documentation and changelog entries are included.

## Benefits of this PR and context:

Closes linuxserver/docker-kasm#83.

Workspace containers get the driver, its libraries and the ICD/vendor configuration injected again, so Vulkan and OpenGL work inside them — whether Kasm asks for the GPU through `device_requests`, through a `"runtime": "nvidia"` Docker run config override, or through a Workspace image that already sets `NVIDIA_VISIBLE_DEVICES`. `--device nvidia.com/gpu=all` also becomes usable directly, since CDI is enabled by default in `dockerd` from 28.3.0 onwards and this image pins Docker 29.

Two things about the current state are worth calling out, as they explain why the old advice stopped working:

* Making the NVIDIA runtime the default inside the DinD layer used to be sufficient on its own. Since nvidia-container-toolkit 1.18.0 the runtime defaults to `jit-cdi`, which builds its specification at container creation time by re-discovering the driver on what it takes to be the host — and that discovery is the step that does not survive being run inside the DinD layer. Doing the generation once, explicitly, at startup, moves that work to a point where it either succeeds or is reported, instead of silently yielding a container without a GPU. 1.18.2 turned the same class of failure into an error rather than an unresolvable device, which points in the same direction.
* A CDI specification is capability-agnostic. The graphics parts of the driver are injected whether or not `graphics` made it into `NVIDIA_DRIVER_CAPABILITIES` for that Workspace, which removes the other half of the "Vulkan specifically is missing" symptom.

Hosts without a GPU are unaffected: the whole block is skipped, and `/etc/docker/daemon.json` and `/etc/nvidia-container-runtime/config.toml` are left exactly as they ship today.

## How Has This Been Tested?

Honest summary: **I had no NVIDIA host available, so the GPU path has not been exercised end to end.** What has been checked:

* `bash -n` on the modified `init-config-kasm/run`, and `readme-vars.yml` parses.
* Every `nvidia-ctk` invocation was checked against the toolkit sources for the version this image installs — `cdi generate --output`, `config --in-place --set`, and `runtime configure --runtime/--set-as-default` (which only logs a "restart the daemon" recommendation, so it is safe to call before `dockerd` is up).
* Ordering: `init-config-kasm` → `init-config-end` → … → `init-services` → `svc-docker`, so the specification and the daemon configuration are in place before `dockerd` starts.
* No-GPU behaviour: with `/dev/nvidiactl` absent the guard is false and nothing is written.

What would need to be confirmed on a GPU host, and I would appreciate a second pair of eyes on:

1. `docker exec -it kasm cat /etc/cdi/nvidia.yaml` is generated and lists the expected devices;
2. `docker exec -it kasm docker info | grep -i runtime` shows `Default Runtime: nvidia`;
3. `vulkaninfo --summary` and `glxinfo -B` inside a Workspace session report the NVIDIA driver;
4. a GPU-less host still starts cleanly and its Workspaces are unchanged.

## Source / References:

* Issue: linuxserver/docker-kasm#83
* nvidia-container-toolkit v1.18.0 — "Default to jit-cdi mode in the nvidia runtime": https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/CHANGELOG.md
* nvidia-container-toolkit release notes (1.18.2 error handling for JIT CDI generation): https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/release-notes.html
* CDI support in the NVIDIA Container Toolkit: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html
* `dockerd` reference — CDI is enabled by default since Docker Engine 28.3.0: https://docs.docker.com/reference/cli/dockerd/
* Kasm GPU acceleration documentation: https://docs.kasm.com/docs/latest/how-to/gpu/index.html

---
_Generated by [Claude Code](https://claude.ai/code) and reviewed by @tigerblue77_